### PR TITLE
[Feat/#6] [Fe Setting] Tradingview 연동

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
 		"react-router": "^7.5.2",
+		"react-ts-tradingview-widgets": "^1.2.8",
 		"zod": "^3.24.3",
 		"zustand": "^5.0.3"
 	},

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-router:
         specifier: ^7.5.2
         version: 7.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-ts-tradingview-widgets:
+        specifier: ^1.2.8
+        version: 1.2.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zod:
         specifier: ^3.24.3
         version: 3.24.3
@@ -1149,6 +1152,12 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react-ts-tradingview-widgets@1.2.8:
+    resolution: {integrity: sha512-ozJwn+0x+Kp2DcqoB9LTDWQHyv3JCdfShb8ooHo+ZB9xjKAXW0irD/gK1deWv4oaAnTxmzKLfmr1QNfAhv+MJw==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.1.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.1.0 || ^19.0.0
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -2456,6 +2465,11 @@ snapshots:
       set-cookie-parser: 2.7.1
       turbo-stream: 2.4.0
     optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+
+  react-ts-tradingview-widgets@1.2.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}

--- a/web/src/pages/main/MainPage.tsx
+++ b/web/src/pages/main/MainPage.tsx
@@ -9,16 +9,16 @@ import { chartArea, container, filterArea, listArea } from './style.css';
 
 export function MainPage() {
   const chartItems: ChartItem[] = SAMPLE_CHARTS;
-  const { timeframe, onChangeTimeframe, timeframeError, symbolId, symbol, onChangeSymbol, symbolError, symbols } =
+  const { interval, onChangeInterval, intervalError, symbolId, symbol, onChangeSymbol, symbolError, symbols } =
     useFilters();
 
   return (
     <div className={`${themeClass} ${container}`}>
       <div className={filterArea}>
         <FilterView
-          timeframe={timeframe}
-          onChangeTimeframe={onChangeTimeframe}
-          timeframeError={timeframeError}
+          interval={interval}
+          onChangeInterval={onChangeInterval}
+          intervalError={intervalError}
           symbolId={symbolId}
           onChangeSymbol={onChangeSymbol}
           symbolError={symbolError}
@@ -27,7 +27,7 @@ export function MainPage() {
       </div>
 
       <div className={chartArea}>
-        <ChartView timeframe={timeframe} symbol={symbol} />
+        <ChartView interval={interval} symbol={symbol} />
       </div>
 
       <div className={listArea}>

--- a/web/src/pages/main/components/ChartView/ChartView.tsx
+++ b/web/src/pages/main/components/ChartView/ChartView.tsx
@@ -1,46 +1,17 @@
-import type { SymbolOption, TimeframeOption } from '@web/shared/types/domain';
-import { chartViewSection, noSymbolMessage, symbolInfo, timeframeInfo } from './style.css';
+import type { IntervalOption, RangeOption, SymbolOption } from '@web/shared/types/domain';
+import { RealTimeChart } from '../TVChart/RealTimeChart';
+import { chartViewSection } from './style.css';
 
 interface ChartViewProps {
-  timeframe: TimeframeOption;
+  interval?: IntervalOption;
+  range?: RangeOption;
   symbol: SymbolOption | null;
 }
 
-export const ChartView: React.FC<ChartViewProps> = ({ timeframe, symbol }) => {
+export const ChartView: React.FC<ChartViewProps> = ({ interval = '5', range = '1D', symbol }) => {
   return (
     <div className={chartViewSection}>
-      <div className={timeframeInfo}>현재 시간 프레임: {formatTimeframe(timeframe)}</div>
-
-      {symbol ? (
-        <div className={symbolInfo}>
-          선택된 종목: {symbol.name} ({symbol.code})
-        </div>
-      ) : (
-        <div className={noSymbolMessage}>선택된 종목이 없습니다</div>
-      )}
+      <RealTimeChart symbol={symbol?.code || ''} interval={interval} range={range} />
     </div>
   );
 };
-
-function formatTimeframe(timeframe: TimeframeOption) {
-  switch (timeframe) {
-    case '5m':
-      return '5분봉';
-    case '15m':
-      return '15분봉';
-    case '30m':
-      return '30분봉';
-    case '1h':
-      return '1시간봉';
-    case '4h':
-      return '4시간봉';
-    case '6h':
-      return '6시간봉';
-    case '12h':
-      return '12시간봉';
-    case '24h':
-      return '일봉';
-    default:
-      return timeframe;
-  }
-}

--- a/web/src/pages/main/components/ChartView/style.css.ts
+++ b/web/src/pages/main/components/ChartView/style.css.ts
@@ -8,37 +8,5 @@ export const chartViewSection = style({
   alignItems: 'center',
   height: '100%',
   color: '#e0e0e0',
-});
-
-export const infoBox = style({
-  padding: '8px 12px',
-  borderRadius: '4px',
-  marginTop: '8px',
   width: '100%',
-  maxWidth: '300px',
-  textAlign: 'center',
 });
-
-export const timeframeInfo = style([
-  infoBox,
-  {
-    backgroundColor: '#000',
-    color: '#fff',
-  },
-]);
-
-export const symbolInfo = style([
-  infoBox,
-  {
-    backgroundColor: '#000',
-    color: '#fff',
-  },
-]);
-
-export const noSymbolMessage = style([
-  infoBox,
-  {
-    backgroundColor: 'rgba(255, 152, 0, 0.1)',
-    color: '#ff9800',
-  },
-]);

--- a/web/src/pages/main/components/FilterView/FilterView.tsx
+++ b/web/src/pages/main/components/FilterView/FilterView.tsx
@@ -1,5 +1,5 @@
-import { TIMEFRAME_OPTIONS } from '@web/shared/constants/filter';
-import type { SymbolOption, TimeframeOption } from '@web/shared/types/domain';
+import { INTERVAL_OPTIONS } from '@web/shared/constants/filter';
+import type { IntervalOption, SymbolOption } from '@web/shared/types/domain';
 import {
   emptyMessage,
   errorMessage,
@@ -84,9 +84,9 @@ function SymbolSelect({ label, symbols, selectedSymbolId, onSelectSymbol, error 
 }
 
 interface FilterViewProps {
-  timeframe: TimeframeOption;
-  onChangeTimeframe: (value: unknown) => void;
-  timeframeError?: string | null;
+  interval: IntervalOption;
+  onChangeInterval: (value: unknown) => void;
+  intervalError?: string | null;
   symbolId: string | number | null;
   onChangeSymbol: (value: unknown) => void;
   symbolError?: string | null;
@@ -94,9 +94,9 @@ interface FilterViewProps {
 }
 
 export const FilterView: React.FC<FilterViewProps> = ({
-  timeframe,
-  onChangeTimeframe,
-  timeframeError,
+  interval,
+  onChangeInterval,
+  intervalError,
   symbolId,
   onChangeSymbol,
   symbolError,
@@ -108,10 +108,10 @@ export const FilterView: React.FC<FilterViewProps> = ({
 
       <FilterSelect
         label="기간 설정"
-        options={TIMEFRAME_OPTIONS}
-        value={timeframe}
-        onChange={onChangeTimeframe}
-        error={timeframeError}
+        options={INTERVAL_OPTIONS}
+        value={interval}
+        onChange={onChangeInterval}
+        error={intervalError}
       />
 
       <SymbolSelect

--- a/web/src/pages/main/components/TVChart/RealTimeChart.tsx
+++ b/web/src/pages/main/components/TVChart/RealTimeChart.tsx
@@ -1,0 +1,12 @@
+import type { IntervalOption, RangeOption } from '@web/shared/types/domain';
+import { AdvancedRealTimeChart } from 'react-ts-tradingview-widgets';
+
+interface TVRealTimeChartProps {
+  symbol: string;
+  interval?: IntervalOption;
+  range?: RangeOption;
+}
+
+export function RealTimeChart({ symbol, interval, range }: TVRealTimeChartProps) {
+  return <AdvancedRealTimeChart theme="dark" symbol={symbol} interval={interval} range={range} />;
+}

--- a/web/src/pages/main/components/TVChart/RealTimeChart.tsx
+++ b/web/src/pages/main/components/TVChart/RealTimeChart.tsx
@@ -1,5 +1,6 @@
 import type { IntervalOption, RangeOption } from '@web/shared/types/domain';
 import { AdvancedRealTimeChart } from 'react-ts-tradingview-widgets';
+import { chartContainer } from './style.css';
 
 interface TVRealTimeChartProps {
   symbol: string;
@@ -8,5 +9,9 @@ interface TVRealTimeChartProps {
 }
 
 export function RealTimeChart({ symbol, interval, range }: TVRealTimeChartProps) {
-  return <AdvancedRealTimeChart theme="dark" symbol={symbol} interval={interval} range={range} />;
+  return (
+    <div className={chartContainer}>
+      <AdvancedRealTimeChart theme="dark" symbol={symbol} interval={interval} range={range} autosize />
+    </div>
+  );
 }

--- a/web/src/pages/main/components/TVChart/style.css.ts
+++ b/web/src/pages/main/components/TVChart/style.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+
+export const chartContainer = style({
+  width: '100%',
+  height: 'calc(100% - 32px)',
+});

--- a/web/src/pages/main/hooks/useFilters.ts
+++ b/web/src/pages/main/hooks/useFilters.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_SYMBOL, DEFAULT_TIMEFRAME, SAMPLE_SYMBOLS } from '@web/shared/constants/filter';
-import type { SymbolOption, TimeframeOption } from '@web/shared/types/domain';
-import { type ValidationResult, safeValidateSymbolId, safeValidateTimeframe } from '@web/shared/utils/validator';
+import { DEFAULT_INTERVAL, DEFAULT_SYMBOL, SAMPLE_SYMBOLS } from '@web/shared/constants/filter';
+import type { IntervalOption, SymbolOption } from '@web/shared/types/domain';
+import { type ValidationResult, safeValidateInterval, safeValidateSymbolId } from '@web/shared/utils/validator';
 import { useCallback, useEffect, useState } from 'react';
 
 export function useFilter<T>(initialValue: T, validator: (value: unknown) => ValidationResult<T>) {
@@ -27,10 +27,10 @@ export function useFilter<T>(initialValue: T, validator: (value: unknown) => Val
 
 export const useFilters = () => {
   const {
-    value: timeframe,
-    updateValue: onChangeTimeframe,
-    error: timeframeError,
-  } = useFilter<TimeframeOption>(DEFAULT_TIMEFRAME as TimeframeOption, safeValidateTimeframe);
+    value: interval,
+    updateValue: onChangeInterval,
+    error: intervalError,
+  } = useFilter<IntervalOption>(DEFAULT_INTERVAL as IntervalOption, safeValidateInterval);
 
   const [symbolId, setSymbolId] = useState<string | number | null>(DEFAULT_SYMBOL);
   const [symbol, setSymbol] = useState<SymbolOption | null>(null);
@@ -79,14 +79,14 @@ export const useFilters = () => {
   }, []);
 
   return {
-    timeframe,
-    onChangeTimeframe,
-    timeframeError,
+    interval,
+    onChangeInterval,
+    intervalError,
     symbolId,
     symbol,
     onChangeSymbol: updateSymbolId,
     symbolError,
     symbols,
-    hasErrors: !!timeframeError || !!symbolError,
+    hasErrors: !!intervalError || !!symbolError,
   };
 };

--- a/web/src/shared/constants/filter.ts
+++ b/web/src/shared/constants/filter.ts
@@ -1,9 +1,9 @@
 import type { ChartItem, FilterOption, SymbolOption } from '../types/domain';
 
 export const SAMPLE_SYMBOLS: SymbolOption[] = [
-  { id: 'btc', name: '비트코인', code: 'BTC-KRW' },
-  { id: 'eth', name: '이더리움', code: 'ETH-KRW' },
-  { id: 'xrp', name: '리플', code: 'XRP-KRW' },
+  { id: 'btc', name: '비트코인', code: 'BTCUSD' },
+  { id: 'eth', name: '이더리움', code: 'ETHUSD' },
+  { id: 'xrp', name: '리플', code: 'XRPUSD' },
 ];
 
 export const SYMBOL_OPTIONS: FilterOption[] = SAMPLE_SYMBOLS.map(symbol => ({
@@ -17,17 +17,19 @@ export const SAMPLE_CHARTS: ChartItem[] = [
   { id: 'xrp', name: '리플' },
 ];
 
-export const TIMEFRAME_OPTIONS: FilterOption[] = [
-  { value: '5m', label: '5분' },
-  { value: '15m', label: '15분' },
-  { value: '30m', label: '30분' },
-  { value: '1h', label: '1시간' },
-  { value: '4h', label: '4시간' },
-  { value: '6h', label: '6시간' },
-  { value: '12h', label: '12시간' },
-  { value: '24h', label: '일봉' },
+export const INTERVAL_OPTIONS: FilterOption[] = [
+  { value: '1', label: '1분' },
+  { value: '5', label: '5분' },
+  { value: '15', label: '15분' },
+  { value: '30', label: '30분' },
+  { value: '60', label: '1시간' },
+  { value: '120', label: '2시간' },
+  { value: '180', label: '3시간' },
+  { value: '240', label: '4시간' },
+  { value: 'D', label: '일봉' },
+  { value: 'W', label: '주봉' },
 ];
 
-export const DEFAULT_TIMEFRAME = '1h';
+export const DEFAULT_INTERVAL = INTERVAL_OPTIONS.length > 0 ? INTERVAL_OPTIONS[0].value : null;
 
 export const DEFAULT_SYMBOL = SYMBOL_OPTIONS.length > 0 ? SYMBOL_OPTIONS[0].value : null;

--- a/web/src/shared/types/domain.ts
+++ b/web/src/shared/types/domain.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
-export const timeframeSchema = z.enum(['5m', '15m', '30m', '1h', '4h', '6h', '12h', '24h']);
-export type TimeframeOption = z.infer<typeof timeframeSchema>;
+export const intervalSchema = z.enum(['1', '3', '5', '15', '30', '60', '120', '180', '240', 'D', 'W']);
+export type IntervalOption = z.infer<typeof intervalSchema>;
+
+export const rangeSchema = z.enum(['1D', '5D', '1M', '3M', '6M', 'YTD', '12M', '60M', 'ALL']);
+export type RangeOption = z.infer<typeof rangeSchema>;
 
 export const symbolSchema = z.object({
   id: z.union([z.number(), z.string()]),

--- a/web/src/shared/utils/validator.ts
+++ b/web/src/shared/utils/validator.ts
@@ -1,21 +1,21 @@
 import {
   type ChartItem,
+  type IntervalOption,
   type SymbolOption,
-  type TimeframeOption,
   chartItemSchema,
+  intervalSchema,
   symbolSchema,
-  timeframeSchema,
 } from '../types/domain';
 
 export type ValidationResult<T> = { success: true; data: T } | { success: false; error: string };
 
-export const validateTimeframe = (input: unknown): TimeframeOption => {
-  return timeframeSchema.parse(input);
+export const validateInterval = (input: unknown): IntervalOption => {
+  return intervalSchema.parse(input);
 };
 
-export const safeValidateTimeframe = (input: unknown): ValidationResult<TimeframeOption> => {
+export const safeValidateInterval = (input: unknown): ValidationResult<IntervalOption> => {
   try {
-    const data = validateTimeframe(input);
+    const data = validateInterval(input);
     return { success: true, data };
   } catch (error) {
     return {


### PR DESCRIPTION
## Issue
close #6 

## Changes
- tradingview widgets 추가
- realtime chart 컴포넌트 추가
- tradingview widget props에 맞춰 변경(timeframe -> interval, range)

## 참고
@widse 
- 종목명은 실제 데이터에 맞춰서 변경 필요할 것 같습니다. 현재는 `BTCUSD`와 같이 구성하였습니다.
- preview

![preview](https://github.com/user-attachments/assets/5303e65e-5b77-44f9-855f-b7c4b2cd7de9)
