### PR TITLE
[Feat/#10] [Fe Setting] i18n(Internationalization) 국제화 적용

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "react": "^19.0.0",
     "react-apexcharts": "^1.7.0",
     "react-dom": "^19.0.0",
+    "react-i18next": "^15.5.1",
     "react-router": "^7.5.2",
     "react-ts-tradingview-widgets": "^1.2.8",
     "zod": "^3.24.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      react-i18next:
+        specifier: ^15.5.1
+        version: 15.5.1(i18next@25.1.2(typescript@5.7.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3)
       react-router:
         specifier: ^7.5.2
         version: 7.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1661,6 +1664,9 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -1684,6 +1690,14 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  i18next@25.1.2:
+    resolution: {integrity: sha512-SP63m8LzdjkrAjruH7SCI3ndPSgjt4/wX7ouUUOzCW/eY+HzlIo19IQSfYA9X3qRiRP1SYtaTsg/Oz/PGsfD8w==}
+    peerDependencies:
+      typescript: ^5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2301,6 +2315,22 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-i18next@15.5.1:
+    resolution: {integrity: sha512-C8RZ7N7H0L+flitiX6ASjq9p5puVJU1Z8VyL3OgM/QOMRf40BMZX+5TkpxzZVcTmOLPX5zlti4InEX5pFyiVeA==}
+    peerDependencies:
+      i18next: '>= 23.2.3'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2857,6 +2887,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -4737,6 +4771,10 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
@@ -4758,6 +4796,12 @@ snapshots:
   human-signals@5.0.0: {}
 
   husky@9.1.7: {}
+
+  i18next@25.1.2(typescript@5.7.3):
+    dependencies:
+      '@babel/runtime': 7.27.0
+    optionalDependencies:
+      typescript: 5.7.3
 
   iconv-lite@0.6.3:
     dependencies:
@@ -5422,6 +5466,16 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-i18next@15.5.1(i18next@25.1.2(typescript@5.7.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.7.3):
+    dependencies:
+      '@babel/runtime': 7.27.0
+      html-parse-stringify: 3.0.1
+      i18next: 25.1.2(typescript@5.7.3)
+      react: 19.1.0
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+      typescript: 5.7.3
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -6011,6 +6065,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  void-elements@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/web/src/common/i18n/i18n.ts
+++ b/web/src/common/i18n/i18n.ts
@@ -1,0 +1,32 @@
+import i18n from 'i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import Backend from 'i18next-http-backend';
+import { initReactI18next } from 'react-i18next';
+
+import enTranslations from './locales/en.json';
+import koTranslations from './locales/ko.json';
+
+i18n
+  // load translation using http -> see /public/locales (i.e. https://github.com/i18next/react-i18next/tree/master/example/react/public/locales)
+  // learn more: https://github.com/i18next/i18next-http-backend
+  // want your translations to be loaded from a professional CDN? => https://github.com/locize/react-tutorial#step-2---use-the-locize-cdn
+  .use(Backend)
+  // detect user language
+  // learn more: https://github.com/i18next/i18next-browser-languageDetector
+  .use(LanguageDetector)
+  // pass the i18n instance to react-i18next.
+  .use(initReactI18next)
+  // init i18next
+  // for all options read: https://www.i18next.com/overview/configuration-options
+  .init({
+    resources: {
+      ko: { translation: koTranslations },
+      en: { translation: enTranslations },
+    },
+    lng: 'ko',
+    fallbackLng: 'en',
+    debug: true,
+    interpolation: {
+      escapeValue: false, // not needed for react as it escapes by default
+    },
+  });

--- a/web/src/common/i18n/index.ts
+++ b/web/src/common/i18n/index.ts
@@ -1,0 +1,1 @@
+export * from './i18n';

--- a/web/src/common/i18n/locales/en.json
+++ b/web/src/common/i18n/locales/en.json
@@ -1,0 +1,12 @@
+{
+  "filter": {
+    "title": "Filtering",
+    "interval": "Interval",
+    "symbol": "Symbol",
+    "selectSymbol": "Select Symbol",
+    "noSymbol": "No available symbols"
+  },
+  "chartList": {
+    "noChart": "No charts"
+  }
+}

--- a/web/src/common/i18n/locales/ko.json
+++ b/web/src/common/i18n/locales/ko.json
@@ -1,0 +1,12 @@
+{
+  "filter": {
+    "title": "필터링",
+    "interval": "기간 설정",
+    "symbol": "종목 설정",
+    "selectSymbol": "종목 선택",
+    "noSymbol": "선택 가능한 종목이 없습니다."
+  },
+  "chartList": {
+    "noChart": "차트가 존재하지 않습니다."
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './common/style/global.css';
 import App from './App.tsx';
+import './common/i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/web/src/pages/main/components/ChartListView/ChartListView.tsx
+++ b/web/src/pages/main/components/ChartListView/ChartListView.tsx
@@ -1,7 +1,7 @@
 import type { ChartItem } from '@web/shared/types/domain';
 import { Suspense, lazy } from 'react';
+import { useTranslation } from 'react-i18next';
 import { chartCard, chartCardHeader, chartCardTitle, chartListSection, emptyMessage } from './style.css';
-
 const CandleStickChart = lazy(() => import('../SideChart/CandleStickChart'));
 
 interface ChartCardProps {
@@ -26,6 +26,8 @@ interface ChartListViewProps {
 }
 
 export const ChartListView: React.FC<ChartListViewProps> = ({ chartItems }) => {
+  const { t } = useTranslation();
+
   return (
     <div className={chartListSection}>
       {chartItems.length > 0 ? (
@@ -35,7 +37,7 @@ export const ChartListView: React.FC<ChartListViewProps> = ({ chartItems }) => {
           ))}
         </>
       ) : (
-        <div className={emptyMessage}>유사한 차트가 존재하지 않습니다.</div>
+        <div className={emptyMessage}>{t('chartList.noChart')}</div>
       )}
     </div>
   );

--- a/web/src/pages/main/components/FilterView/FilterView.tsx
+++ b/web/src/pages/main/components/FilterView/FilterView.tsx
@@ -1,5 +1,7 @@
 import { INTERVAL_OPTIONS } from '@web/shared/constants/filter';
 import type { IntervalOption, SymbolOption } from '@web/shared/types/domain';
+import { useTranslation } from 'react-i18next';
+
 import {
   emptyMessage,
   errorMessage,
@@ -49,6 +51,8 @@ interface SymbolSelectProps {
 }
 
 function SymbolSelect({ label, symbols, selectedSymbolId, onSelectSymbol, error }: SymbolSelectProps) {
+  const { t } = useTranslation();
+
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value;
     onSelectSymbol(value || null);
@@ -67,7 +71,7 @@ function SymbolSelect({ label, symbols, selectedSymbolId, onSelectSymbol, error 
             value={selectedSymbolId?.toString() || ''}
             onChange={handleChange}
           >
-            <option value="">종목 선택</option>
+            <option value="">{t('filter.selectSymbol')}</option>
             {symbols.map(symbol => (
               <option key={symbol.id} value={symbol.id.toString()}>
                 {symbol.name} ({symbol.code})
@@ -77,7 +81,7 @@ function SymbolSelect({ label, symbols, selectedSymbolId, onSelectSymbol, error 
           {error && <div className={errorMessage}>{error}</div>}
         </>
       ) : (
-        <div className={emptyMessage}>선택 가능한 종목이 없습니다.</div>
+        <div className={emptyMessage}>{t('filter.noSymbol')}</div>
       )}
     </div>
   );
@@ -102,12 +106,13 @@ export const FilterView: React.FC<FilterViewProps> = ({
   symbolError,
   symbols,
 }) => {
+  const { t } = useTranslation();
   return (
     <div className={filterSection}>
-      <h3 className={filterTitle}>Filtering</h3>
+      <h3 className={filterTitle}>{t('filter.title')}</h3>
 
       <FilterSelect
-        label="기간 설정"
+        label={t('filter.interval')}
         options={INTERVAL_OPTIONS}
         value={interval}
         onChange={onChangeInterval}
@@ -115,7 +120,7 @@ export const FilterView: React.FC<FilterViewProps> = ({
       />
 
       <SymbolSelect
-        label="종목 설정"
+        label={t('filter.symbol')}
         symbols={symbols}
         selectedSymbolId={symbolId}
         onSelectSymbol={onChangeSymbol}


### PR DESCRIPTION
## Issue
#10 

## Changes
- i18n 설정(react, node, languagedetector)
- 기개발된 컴포넌트 적용

## 참고
@widse 
- 논의사항
  - en/ko를 어떻게 관리할것인지(폴더 구분, API 응답에 대한 메세지)
  - 적용 방법
    - 번역 파일을 직접 import
    - google spreadsheet api
    - custom backend
    - (현재의 아이디어)기본 번역 파일을 직접 import + google spreadsheet를 추가 사용(백엔드가 필요 x)
- https://brunch.co.kr/@suyoung/13
- https://react.i18next.com/latest/using-with-hooks
- https://meetup.nhncloud.com/posts/295?ref=devlog
- https://soojae.tistory.com/70#%EA%B5%AC%EA%B8%80%20%EC%8A%A4%ED%94%84%EB%A0%88%EB%93%9C%20%EC%8B%9C%ED%8A%B8%EC%97%90%20ChatGPT%20%ED%99%95%EC%9E%A5%20%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9E%A8%20%EC%84%A4%EC%B9%98-1