### PR TITLE
[Feat/#61] Docker와 Nginx를 이용해 Let's Encrypt로 SSL 인증서 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# let's encrypt
+init-letsencrypt.sh
+infra/nginx/letsencrypt/
+infra/nginx/www/
+
+# data
+data/
+infra/mysql/data/
+
+# etc
+.DS_Store
+
+# env
+.env.*
+.env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,19 +5,31 @@ services:
     image: nginx
     restart: always
     ports:
-      - '8000:8000'
+      - '80:80'  # HTTP 
+      - '443:443' # HTTPS
     volumes:
       - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./infra/nginx/letsencrypt:/etc/letsencrypt
+      - ./infra/nginx/www:/var/www/certbot
     environment:
       - TZ=Asia/Seoul
+
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    volumes:
+      - ./infra/nginx/letsencrypt:/etc/letsencrypt
+      - ./infra/nginx/www:/var/www/certbot
+    depends_on:
+      - nginx
 
   db:
     image: mysql:latest
     environment:
-      MYSQL_DATABASE: <MYSQL_DATABASE>
-      MYSQL_USER: <MYSQL_USER>
-      MYSQL_PASSWORD: <MYSQL_PASSWORD>
-      MYSQL_ROOT_PASSWORD: <MYSQL_ROOT_PASSWORD>
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     ports:
       - '3306:3306'
     volumes:

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -19,9 +19,15 @@ http {
   upstream api {
     server api:8001;
   }
+
   server {
-    listen 8000;
-    server_name _;
+    listen 443 ssl;
+    server_name [DOMAIN];
+
+    # https://nginx.org/en/docs/http/configuring_https_servers.html
+    ssl_certificate /etc/letsencrypt/live/[DOMAIN]/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/[DOMAIN]/privkey.pem;
+
     location / {
       proxy_pass http://web;
       proxy_set_header Host $host;
@@ -51,6 +57,20 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       add_header Content-Type application/json;
+    }
+  }
+
+  server {
+    listen 80;
+    server_name [DOMAIN];
+
+    location /.well-known/acme-challenge/ {
+      allow all;
+      root /var/www/certbot;
+    }
+
+    location / {
+      return 301 https://$host$request_uri;
     }
   }
 }


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [x] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
nginx에 https를 위한 ssl 인증 설정을 하였습니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #61 
<!-- close #1 -->

## ✅ 작업 목록
- certbot 추가
- nginx에 인증서 적용
<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항
@widse 
- 추가 서비스를 위한 domain 규칙 협의를 진행하고 싶습니다.
  - ex) sub.domain.com, domain.com/sub
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
- https://akk9132.gitbook.io/seungdeok-log/devops/ci-and-cd/docker-nginx-lets-encrypt-ssl
<!-- Screenshot, References 기재 -->
