### PR TITLE
Rate Limiting with NGINX

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -13,6 +13,9 @@ http {
   gzip_vary on;
   gzip_comp_level 5;
 
+  # rate limit
+  limit_req_zone $binary_remote_addr zone=limit:10m rate=10r/s;
+
   upstream web {
     server web:8002;
   }
@@ -22,6 +25,10 @@ http {
   server {
     listen 8000;
     server_name _;
+    
+    limit_req zone=limit burst=20 nodelay;
+    limit_req_status 429;
+
     location / {
       proxy_pass http://web;
       proxy_set_header Host $host;


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
Nginx에 Rate Limit를 설정하였습니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #57 
<!-- close #1 -->

## ✅ 작업 목록
- limit_req_zone 설정
- limit_req_status 에러 추가
<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
- options
  - $binary_remote_addr: 동일 IP에 대해서 요청 속도를 제한하도록 기준을 설정
  - burst: 허용 가능한 요청 수보다 더 많은 요청이 들어왔을 경우, 허용 가능한 요청 이외에 요청들을 대기열 큐(허용 가능한 요청 수보다 더 많은 요청이 들어왔을 경우, 허용 가능한 요청 이외에 요청들을 대기열 큐)
  - nodelay: 기본적으로는 1s 10개 허용, 더 많은 요청이 왔을 때는 일시적으로 1초에 burst 값(20) 요청 허용
  - rate: 1초에 몇개의 요청을 허용 (r: request, s: seconds)
  - zone: IP주소의 상태, 요청 제한이 걸려있는 URL에 접근한 빈도 등을 저장할 때 필요한 메모리
  - limit_req_status: limit을 넘었을 때 429(too many requests) 에러를 발생

<!-- Screenshot, References 기재 -->

- https://nginx.org/en/docs/http/ngx_http_limit_req_module.html
