### PR TITLE
[Feat/#68]  서비스의 활성상태를 확인하기 위한 hooks 추가

### DIFF
--- a/web/src/shared/hooks/useOnlineStatus.ts
+++ b/web/src/shared/hooks/useOnlineStatus.ts
@@ -1,0 +1,22 @@
+import { useEffect, useSyncExternalStore } from 'react';
+
+/**
+ * @param callback 온라인 상태 변경 시 호출할 콜백 함수
+ */
+export function useOnlineStatus(callback: (isOnline: boolean) => void): void {
+  const isOnline = useSyncExternalStore<boolean>(
+    cb => {
+      window.addEventListener('online', cb);
+      window.addEventListener('offline', cb);
+      return () => {
+        window.removeEventListener('online', cb);
+        window.removeEventListener('offline', cb);
+      };
+    },
+    () => navigator.onLine
+  );
+
+  useEffect(() => {
+    callback(isOnline);
+  }, [callback, isOnline]);
+}

--- a/web/src/shared/hooks/useVisibilityChange.ts
+++ b/web/src/shared/hooks/useVisibilityChange.ts
@@ -1,0 +1,18 @@
+import { useEffect, useSyncExternalStore } from 'react';
+
+/**
+ * @param callback Visibility 변경 시 호출할 콜백 함수
+ */
+export function useVisibilityChange(callback: (state: 'visible' | 'hidden') => void): void {
+  const visibilityState = useSyncExternalStore(
+    cb => {
+      document.addEventListener('visibilitychange', cb);
+      return () => document.removeEventListener('visibilitychange', cb);
+    },
+    () => document.visibilityState
+  );
+
+  useEffect(() => {
+    callback(visibilityState);
+  }, [callback, visibilityState]);
+}


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
활성상태(online/offline, visibilitychange)를 체크하는 hook을 추가하였습니다. 
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #68 
<!-- close #1 -->

## ✅ 작업 목록
- online/offline 체크 hook
- visibilitychange 체크 hook

<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
- useSyncExternalStore를 활용하여 window api 값의 변경을 react의 렌더링에 동기화시키고자하였습니다.
- https://react.dev/reference/react/useSyncExternalStore#subscribing-to-a-browser-api
<!-- Screenshot, References 기재 -->
