### PR TITLE
chore(@docker-compose): setting timezone (Asia/Seoul)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      TZ: Asia/Seoul
     ports:
       - '3306:3306'
     volumes:
@@ -41,6 +42,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - '8001:8001'
+    environment:
+      - TZ=Asia/Seoul
 
   web: 
     build:
@@ -48,4 +51,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - '8002:8002'
+    environment:
+      - TZ=Asia/Seoul
     

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - ./infra/nginx/letsencrypt:/etc/letsencrypt
       - ./infra/nginx/www:/var/www/certbot
     environment:
-      - TZ=Asia/Seoul
+      - TZ: Asia/Seoul
 
   certbot:
     image: certbot/certbot
@@ -52,5 +52,5 @@ services:
     ports:
       - '8002:8002'
     environment:
-      - TZ=Asia/Seoul
+      - TZ: Asia/Seoul
     


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [x] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
- fastapi scheduler 동작 시 서버 환경의 timezone 미설정으로 인한 DB update 이슈 발생
- docker compose 에서 각 환경 timezone 설정 하여 통일
<!-- PR 설명 -->

## 관련된 이슈 넘버
- #74 

### close
close #74 
<!-- close #1 -->

## ✅ 작업 목록
- `docker-compose.yaml` timezone 설정 (Asia/Seoul)
<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
