### PR TITLE
[Feat/#92] web 정적 데이터 서빙

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,9 @@ version: "3"
 services:
   nginx:
     container_name: nginx
-    image: nginx:stable-otel
+    build:
+      context: ./web
+      dockerfile: Dockerfile
     restart: always
     ports:
       - "80:80" # HTTP
@@ -43,14 +45,5 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8001:8001"
-    environment:
-      - TZ=Asia/Seoul
-
-  web:
-    build:
-      context: ./web
-      dockerfile: Dockerfile
-    ports:
-      - "8002:8002"
     environment:
       - TZ=Asia/Seoul

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -26,9 +26,6 @@ http {
   access_log /var/log/nginx/access.log compression;
   error_log /var/log/nginx/error.log warn;
 
-  upstream web {
-    server web:8002;
-  }
   upstream api {
     server api:8001;
   }
@@ -57,29 +54,27 @@ http {
       # otel header 추가
       otel_trace_context inject;
 
-      proxy_pass http://web;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
+      root /usr/share/nginx/html;
+      index   index.html;
+      try_files $uri $uri/ /index.html;
 
+      # HTML 파일은 no-cache
+      location ~* \.html$ {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "public, no-cache";
+      }
+
+      # JS, CSS 파일은 1년 캐시
       location ~* \.(js|css)$ {
-        proxy_pass http://web;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        add_header Cache-Control "public, max-age=31536000"; # 1year
+        root /usr/share/nginx/html;
+        add_header Cache-Control "public, max-age=31536000";
         add_header Vary "Origin, Accept-Encoding";
       }
-    
+      
+      # 이미지 파일은 1일 캐시
       location ~* \.(png|jpg|jpeg|gif|ico|svg|webp)$ {
-        proxy_pass http://web;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        add_header Cache-Control "public, max-age=86400"; # 1day
+        root /usr/share/nginx/html;
+        add_header Cache-Control "public, max-age=86400";
       }
     }
     location /api {

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,16 +5,10 @@ RUN corepack enable
 COPY . /app
 WORKDIR /app
 
-FROM base AS prod-deps
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-
 FROM base AS build
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm run build
 
-FROM base
-COPY --from=prod-deps /app/node_modules /app/node_modules
-COPY --from=build /app/dist /app/dist
-EXPOSE 8002
-CMD [ "pnpm", "preview", "--host", "0.0.0.0", "--port", "8002" ]
+FROM nginx:stable-otel
+COPY --from=build /app/dist /usr/share/nginx/html
 


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [x] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명

<!-- PR 설명 -->

## 관련된 이슈 넘버
close #92 
<!-- close #1 -->

## ✅ 작업 목록
- web build 파일을 nginx로 복사
- nginx.conf 변경
- docker compose 수정(web 서비스 제거)
<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항
- 우선 web에 의존성이 있는 Dockerfile이기 때문에 web쪽에 넣어뒀는데요. 기술적으로는 문제가 없을 것 같지만 아래 두 가지 측면에서 논의사항을 올렸습니다.
  -  nginx.conf, web build 각각의 변경에도 전체 빌드 프로세스를 진행하는 점
  - 결국 end 위치에 있는 서비스는 nginx이기 때문에 두 서비스를 가까이 두는것

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
- https://docs.nginx.com/nginx/admin-guide/web-server/serving-static-content/
- https://nginxstore.com/docs/nginx-plus/nginx-static-content-%EC%A0%9C%EA%B3%B5/
<!-- Screenshot, References 기재 -->
