### PR TITLE
[Feat/#107] App 전역 hook들의 중복 호출 방지 및 관심사 분리

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,11 @@
 import { useGA4Init } from '@web/shared/hooks/useGA';
 import { RQProvider } from '@web/shared/providers/RQProvider';
 import { AppRouterProvider } from '@web/shared/providers/RouterProvider';
+import { useChannelIO } from './shared/hooks/useChannelIO';
 
 function App() {
   useGA4Init();
+  useChannelIO();
 
   return (
     <RQProvider>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,11 @@
 import { useGA4Init } from '@web/shared/hooks/useGA';
 import { RQProvider } from '@web/shared/providers/RQProvider';
 import { AppRouterProvider } from '@web/shared/providers/RouterProvider';
-import { useChannelIO } from './shared/hooks/useChannelIO';
+import { useChannelIOInit } from './shared/hooks/useChannelIO';
 
 function App() {
   useGA4Init();
-  useChannelIO();
+  useChannelIOInit();
 
   return (
     <RQProvider>

--- a/web/src/shared/hooks/useChannelIO.ts
+++ b/web/src/shared/hooks/useChannelIO.ts
@@ -1,6 +1,5 @@
 import * as ChannelService from '@channel.io/channel-web-sdk-loader';
-import { useEffect } from 'react';
-import { useLocation } from 'react-router';
+import { useEffect, useRef } from 'react';
 
 interface UseChannelIOOptions {
   disabledPaths?: RegExp[];
@@ -9,16 +8,17 @@ interface UseChannelIOOptions {
 export function useChannelIO({ disabledPaths = [] }: UseChannelIOOptions = {}) {
   const isChannelIOEnabled = import.meta.env.VITE_FEATURE_CHANNELIO === 'true';
   const pluginKey = import.meta.env.VITE_CHANNELIO_PLUGIN_KEY;
-  const { pathname } = useLocation();
+  const initRef = useRef(false);
 
   useEffect(() => {
-    if (!isChannelIOEnabled || !pluginKey) {
+    if (!isChannelIOEnabled || !pluginKey || initRef.current) {
       if (import.meta.env.DEV) {
         console.warn('ChannelIO configuration missing');
       }
       return;
     }
 
+    initRef.current = true;
     ChannelService.loadScript();
     ChannelService.boot({
       pluginKey,
@@ -30,16 +30,16 @@ export function useChannelIO({ disabledPaths = [] }: UseChannelIOOptions = {}) {
   }, []);
 
   useEffect(() => {
-    if (!isChannelIOEnabled || !pluginKey) return;
+    if (!isChannelIOEnabled || !pluginKey || typeof window === 'undefined') return;
 
-    const shouldHide = disabledPaths.some(path => path.test(pathname));
+    const shouldHide = disabledPaths.some(path => path.test(window.location.pathname));
 
     if (shouldHide) {
       ChannelService.hideChannelButton();
     } else {
       ChannelService.showChannelButton();
     }
-  }, [pathname, disabledPaths]);
+  }, [disabledPaths]);
 
   return {
     show: () => ChannelService.showChannelButton(),

--- a/web/src/shared/hooks/useChannelIO.ts
+++ b/web/src/shared/hooks/useChannelIO.ts
@@ -29,6 +29,7 @@ export function useChannelIO({ disabledPaths = [] }: UseChannelIOOptions = {}) {
     });
 
     return () => {
+      initRef.current = false;
       ChannelService.shutdown();
     };
   }, []);

--- a/web/src/shared/hooks/useChannelIO.ts
+++ b/web/src/shared/hooks/useChannelIO.ts
@@ -11,10 +11,14 @@ export function useChannelIO({ disabledPaths = [] }: UseChannelIOOptions = {}) {
   const initRef = useRef(false);
 
   useEffect(() => {
-    if (!isChannelIOEnabled || !pluginKey || initRef.current) {
+    if (!isChannelIOEnabled || !pluginKey) {
       if (import.meta.env.DEV) {
         console.warn('ChannelIO configuration missing');
       }
+      return;
+    }
+
+    if (initRef.current) {
       return;
     }
 

--- a/web/src/shared/hooks/useGA.ts
+++ b/web/src/shared/hooks/useGA.ts
@@ -9,11 +9,17 @@ export const useGA4Init = () => {
   const initRef = useRef(false);
 
   useEffect(() => {
-    if (!isLocalhost && !initRef.current) {
-      initRef.current = true;
-      ReactGA.initialize(import.meta.env.VITE_GOOGLE_ANALYTICS_TRAKING_ID);
-      console.log('GA4 initialized');
+    if (isLocalhost || initRef.current) {
+      return;
     }
+
+    initRef.current = true;
+    ReactGA.initialize(import.meta.env.VITE_GOOGLE_ANALYTICS_TRAKING_ID);
+    console.log('GA4 initialized');
+
+    return () => {
+      initRef.current = true;
+    };
   }, []);
 };
 

--- a/web/src/shared/hooks/useGA.ts
+++ b/web/src/shared/hooks/useGA.ts
@@ -1,11 +1,16 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import ReactGA from 'react-ga4';
 import type { UaEventOptions } from 'react-ga4/types/ga4';
 import { useLocation } from 'react-router';
 
+const isLocalhost = window.location.hostname === 'localhost';
+
 export const useGA4Init = () => {
+  const initRef = useRef(false);
+
   useEffect(() => {
-    if (!window.location.href.includes('localhost')) {
+    if (!isLocalhost && !initRef.current) {
+      initRef.current = true;
       ReactGA.initialize(import.meta.env.VITE_GOOGLE_ANALYTICS_TRAKING_ID);
       console.log('GA4 initialized');
     }
@@ -16,14 +21,16 @@ export const useGARouteTracking = () => {
   const location = useLocation();
 
   useEffect(() => {
-    ReactGA.set({ page: location.pathname });
-    ReactGA.send('pageview');
-  }, [location]);
+    if (!isLocalhost) {
+      ReactGA.set({ page: location.pathname });
+      ReactGA.send('pageview');
+    }
+  }, [location.pathname]);
 };
 
 export const useGAEvent = () => {
   const triggerEvent = (action: string, category: string, params: Omit<UaEventOptions, 'action' | 'category'>) => {
-    if (!window.location.href.includes('localhost')) {
+    if (!isLocalhost) {
       ReactGA.event({
         transport: 'beacon',
         action,

--- a/web/src/shared/providers/RouterProvider.tsx
+++ b/web/src/shared/providers/RouterProvider.tsx
@@ -1,13 +1,11 @@
 import { Suspense, lazy } from 'react';
 import { Outlet, RouterProvider, createBrowserRouter } from 'react-router';
-import { useChannelIO } from '../hooks/useChannelIO';
 import { useGARouteTracking } from '../hooks/useGA';
 
 const MainPage = lazy(() => import('@web/pages/main/MainPage'));
 
 const RootLayout = () => {
   useGARouteTracking();
-  useChannelIO();
 
   return <Outlet />;
 };

--- a/web/src/shared/providers/RouterProvider.tsx
+++ b/web/src/shared/providers/RouterProvider.tsx
@@ -1,11 +1,13 @@
 import { Suspense, lazy } from 'react';
 import { Outlet, RouterProvider, createBrowserRouter } from 'react-router';
+import { useChannelIOVisibility } from '../hooks/useChannelIO';
 import { useGARouteTracking } from '../hooks/useGA';
 
 const MainPage = lazy(() => import('@web/pages/main/MainPage'));
 
 const RootLayout = () => {
   useGARouteTracking();
+  useChannelIOVisibility();
 
   return <Outlet />;
 };


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
외부 서비스 초기화 hook의 중복 호출을 방지하고 관심사를 분리하기 위한 리팩토링 작업입니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #107 
<!-- close #1 -->

## ✅ 작업 목록
- ChannelIO, GA를 route hook과 init hook으로 분리하여 각 위치로 분리
  - RootLayout은 라우팅 관련 역할만 담당, 외부 서비스 초기화는 App 레벨에서 처리
- React Strict Mode 환경에서 중복 초기화 방지 로직 추가
  - 앱 전체 생명주기에서 1회만 초기화되도록 보장
- 로컬 개발 환경 감지 로직 추가

<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [x] local code lint 검사를 진행하셨나요?
- [x] loca ci test를 진행하셨나요?

## 📚 논의사항
- ga pageview tracking와 route별 channelIO는 router단 관심사라고 생각하여 route부분에 두고 app은 GA, ChannelIO의 초기화를 담당하도록 분리하였습니다.
- 로컬 개발 시 ChannelIO 초기화 스킵을 하지 않고 있는데요. 초기화 여부 결정 논의하고 싶습니다.

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
- https://react.dev/reference/react/StrictMode
- https://api.reactrouter.com/v7/interfaces/react_router.Location.html
  - location에는 host, hostname이 없는데요. window.location.hostname을 이용하여 localhost를 구분하였습니다.
<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved integration of ChannelIO and Google Analytics by ensuring each is initialized only once per session.
* **Refactor**
  * Streamlined the ChannelIO hook to remove dependency on React Router and use direct pathname access.
  * Unified and improved localhost detection for Google Analytics, preventing tracking in local environments.
  * Relocated ChannelIO initialization from the router provider to the main app component for better structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->