### PR TITLE
[Feat/#84] chart UX 개선 작업

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "i18next": "^25.1.2",
     "i18next-browser-languagedetector": "^8.1.0",
     "i18next-http-backend": "^3.0.2",
+    "lucide-react": "^0.539.0",
     "react": "^19.0.0",
     "react-apexcharts": "^1.7.0",
     "react-dom": "^19.0.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       i18next-http-backend:
         specifier: ^3.0.2
         version: 3.0.2
+      lucide-react:
+        specifier: ^0.539.0
+        version: 0.539.0(react@19.1.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -3804,6 +3807,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.539.0:
+    resolution: {integrity: sha512-VVISr+VF2krO91FeuCrm1rSOLACQUYVy7NQkzrOty52Y8TlTPcXcMdQFj9bYzBgXbWCiywlwSZ3Z8u6a+6bMlg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
@@ -9117,6 +9125,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.539.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   lunr@2.3.9: {}
 

--- a/web/src/__tests__/pages/MainPage.spec.tsx
+++ b/web/src/__tests__/pages/MainPage.spec.tsx
@@ -1,4 +1,4 @@
-import { act, screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 import { renderWithRouter } from '../renderWithRouter';
@@ -52,5 +52,26 @@ describe('Main 페이지', () => {
     // select가 없는 것을 확인
     const symbolSelect = screen.queryByRole('combobox', { name: /filter.symbol/ });
     expect(symbolSelect).toBeNull();
+  });
+
+  test('3. 라이브 차트 토글 버튼 클릭 시 라이브 버튼이 비활성화되고 딜레이 버튼이 활성화되는지 테스트합니다.', async () => {
+    const { router } = renderWithRouter({ initialEntries: ['/'] });
+
+    await act(async () => {
+      router.navigate('/');
+    });
+
+    await waitFor(async () => {
+      // given
+      const initialButton = screen.getByRole('button', { name: /live on/ });
+      expect(initialButton).toBeTruthy();
+
+      // when
+      await userEvent.click(initialButton);
+
+      // then
+      const clickedButton = screen.getByRole('button', { name: /live off/ });
+      expect(clickedButton).toBeTruthy();
+    });
   });
 });

--- a/web/src/__tests__/pages/MainPage.spec.tsx
+++ b/web/src/__tests__/pages/MainPage.spec.tsx
@@ -54,7 +54,7 @@ describe('Main 페이지', () => {
     expect(symbolSelect).toBeNull();
   });
 
-  test('3. 라이브 차트 토글 버튼 클릭 시 라이브 버튼이 비활성화되고 딜레이 버튼이 활성화되는지 테스트합니다.', async () => {
+  test('3. 라이브 차트 토글 버튼 클릭 시 라이브 버튼이 활성화되고 딜레이 버튼이 비활성화되는지 테스트합니다.', async () => {
     const { router } = renderWithRouter({ initialEntries: ['/'] });
 
     await act(async () => {
@@ -63,14 +63,14 @@ describe('Main 페이지', () => {
 
     await waitFor(async () => {
       // given
-      const initialButton = screen.getByRole('button', { name: /live on/ });
+      const initialButton = screen.getByRole('button', { name: /live off/ });
       expect(initialButton).toBeTruthy();
 
       // when
       await userEvent.click(initialButton);
 
       // then
-      const clickedButton = screen.getByRole('button', { name: /live off/ });
+      const clickedButton = screen.getByRole('button', { name: /live on/ });
       expect(clickedButton).toBeTruthy();
     });
   });

--- a/web/src/pages/main/components/ChartListView/ChartListView.tsx
+++ b/web/src/pages/main/components/ChartListView/ChartListView.tsx
@@ -1,12 +1,14 @@
 import type { ChartSimilarityBase, ChartSimilarityList } from '@web/shared/api/models';
 import { AsyncBoundary } from '@web/shared/components/AsyncBoundary';
 import type { SymbolOption } from '@web/shared/types/domain';
+import { ArrowRightIcon } from 'lucide-react';
 import { lazy } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   chartCard,
   chartCardChartWrapper,
   chartCardHeader,
+  chartCardLinkButton,
   chartCardSkeleton,
   chartCardTitle,
   chartListHeader,
@@ -19,9 +21,10 @@ const CandleStickChart = lazy(() => import('../SideChart/CandleStickChart'));
 
 interface ChartCardProps {
   chart: ChartSimilarityBase;
+  onClickChart: () => void;
 }
 
-const ChartCard: React.FC<ChartCardProps> = ({ chart }) => {
+const ChartCard: React.FC<ChartCardProps> = ({ chart, onClickChart }) => {
   return (
     <div className={chartCard}>
       <div className={chartCardHeader}>
@@ -29,6 +32,9 @@ const ChartCard: React.FC<ChartCardProps> = ({ chart }) => {
           {chart.start_time.replace('T', ' ')} ~<br />
           {chart.end_time.replace('T', ' ')}
         </h4>
+        <button type="button" className={chartCardLinkButton} onClick={onClickChart}>
+          <ArrowRightIcon size={20} />
+        </button>
       </div>
       <AsyncBoundary
         pendingFallback={<div className={chartCardSkeleton} />}
@@ -50,6 +56,14 @@ interface ChartListViewProps {
 export const ChartListView: React.FC<ChartListViewProps> = ({ symbol, chartItems }) => {
   const { t } = useTranslation();
 
+  const handleClickChart = (chart: ChartSimilarityBase) => {
+    console.log({
+      symbol: chart.symbol,
+      start_time: chart.start_time,
+      end_time: chart.end_time,
+    });
+  };
+
   return (
     <div className={chartListSection}>
       <div className={chartListHeader}>
@@ -58,7 +72,11 @@ export const ChartListView: React.FC<ChartListViewProps> = ({ symbol, chartItems
       {chartItems?.similarities && chartItems?.similarities.length > 0 ? (
         <>
           {chartItems?.similarities.map(chart => (
-            <ChartCard key={`${chart.symbol}-${chart.start_time}`} chart={chart} />
+            <ChartCard
+              key={`${chart.symbol}-${chart.start_time}`}
+              chart={chart}
+              onClickChart={() => handleClickChart(chart)}
+            />
           ))}
         </>
       ) : (

--- a/web/src/pages/main/components/ChartListView/style.css.ts
+++ b/web/src/pages/main/components/ChartListView/style.css.ts
@@ -29,20 +29,19 @@ export const chartCard = style({
   borderRadius: '8px',
   border: '1px solid #333333',
   backgroundColor: '#252525',
-  transition: 'transform 0.2s, box-shadow 0.2s, background-color 0.2s',
+  transition: 'box-shadow 0.2s, background-color 0.2s',
   position: 'relative',
-  ':hover': {
-    transform: 'translateY(-2px)',
-  },
 });
 
 export const chartCardHeader = style({
   display: 'flex',
   alignItems: 'center',
-  flexDirection: 'column',
+  justifyContent: 'space-between',
   position: 'absolute',
   bottom: 12,
   left: 12,
+  zIndex: 1,
+  width: 'calc(100% - 24px)',
 });
 
 export const chartCardTitle = style({
@@ -73,4 +72,19 @@ export const chartCardSkeleton = style({
 
 export const chartCardChartWrapper = style({
   height: CHART_HEIGHT,
+});
+
+export const chartCardLinkButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 8,
+  borderRadius: '50%',
+  backgroundColor: '#333333',
+  cursor: 'pointer',
+  transition: 'background-color 0.2s, transform 0.2s',
+  ':hover': {
+    backgroundColor: '#444444',
+    transform: 'translateX(4px)',
+  },
 });

--- a/web/src/pages/main/components/ChartView/ChartView.tsx
+++ b/web/src/pages/main/components/ChartView/ChartView.tsx
@@ -1,8 +1,13 @@
 import { useToggle } from '@web/shared/hooks/useToggle';
 import type { IntervalOption, RangeOption, SymbolOption } from '@web/shared/types/domain';
-import { FinancialChart } from '../FinancialChart';
+import { Suspense, lazy } from 'react';
 import { LiveToggle } from '../LiveToggle';
-import { RealTimeChart } from '../TVChart/RealTimeChart';
+
+const FinancialChart = lazy(() => import('../FinancialChart').then(module => ({ default: module.FinancialChart })));
+const RealTimeChart = lazy(() =>
+  import('../TVChart/RealTimeChart').then(module => ({ default: module.RealTimeChart }))
+);
+
 import { chartViewSection } from './style.css';
 
 interface ChartViewProps {
@@ -47,11 +52,16 @@ export const ChartView: React.FC<ChartViewProps> = ({ interval = '5', range = '1
   return (
     <div className={chartViewSection}>
       <LiveToggle value={isLive} onChange={onToggle} />
-      {isLive ? (
-        <RealTimeChart symbol={symbol?.code || ''} interval={interval} range={range} />
-      ) : (
-        <FinancialChart data={generateMockData(200)} />
-      )}
+      <div style={{ display: isLive ? 'none' : 'block', height: '100%', width: '100%' }}>
+        <Suspense>
+          <FinancialChart data={generateMockData(200)} />
+        </Suspense>
+      </div>
+      <div style={{ display: isLive ? 'block' : 'none', height: '100%', width: '100%' }}>
+        <Suspense>
+          <RealTimeChart symbol={symbol?.code || ''} interval={interval} range={range} />
+        </Suspense>
+      </div>
     </div>
   );
 };

--- a/web/src/pages/main/components/ChartView/ChartView.tsx
+++ b/web/src/pages/main/components/ChartView/ChartView.tsx
@@ -1,4 +1,6 @@
+import { useToggle } from '@web/shared/hooks/useToggle';
 import type { IntervalOption, RangeOption, SymbolOption } from '@web/shared/types/domain';
+import { LiveToggle } from '../LiveToggle';
 import { RealTimeChart } from '../TVChart/RealTimeChart';
 import { chartViewSection } from './style.css';
 
@@ -9,8 +11,11 @@ interface ChartViewProps {
 }
 
 export const ChartView: React.FC<ChartViewProps> = ({ interval = '5', range = '1D', symbol }) => {
+  const [isLive, onToggle] = useToggle(true);
+
   return (
     <div className={chartViewSection}>
+      <LiveToggle value={isLive} onChange={onToggle} />
       <RealTimeChart symbol={symbol?.code || ''} interval={interval} range={range} />
     </div>
   );

--- a/web/src/pages/main/components/ChartView/ChartView.tsx
+++ b/web/src/pages/main/components/ChartView/ChartView.tsx
@@ -1,5 +1,6 @@
 import { useToggle } from '@web/shared/hooks/useToggle';
 import type { IntervalOption, RangeOption, SymbolOption } from '@web/shared/types/domain';
+import { FinancialChart } from '../FinancialChart';
 import { LiveToggle } from '../LiveToggle';
 import { RealTimeChart } from '../TVChart/RealTimeChart';
 import { chartViewSection } from './style.css';
@@ -10,13 +11,47 @@ interface ChartViewProps {
   symbol: SymbolOption | null;
 }
 
+const generateMockData = (length: number) => {
+  let currentPrice = 100;
+  return Array.from({ length }, (_, i) => {
+    const time = new Date(Date.now() - (length - 1 - i) * 1000).toISOString();
+
+    // 이전 가격 기반으로 변동
+    const volatility = 0.02; // 2% 변동성
+    const trend = (Math.random() - 0.5) * volatility;
+
+    const open = currentPrice;
+    const priceChange = currentPrice * trend;
+    const close = open + priceChange;
+
+    // 캔들 내 변동 범위
+    const wickRange = Math.abs(priceChange) + currentPrice * 0.01;
+    const high = Math.max(open, close) + Math.random() * wickRange;
+    const low = Math.min(open, close) - Math.random() * wickRange;
+
+    currentPrice = close; // 다음 캔들의 시작점
+
+    return {
+      time,
+      open: Number(open.toFixed(2)),
+      high: Number(high.toFixed(2)),
+      low: Number(low.toFixed(2)),
+      close: Number(close.toFixed(2)),
+    };
+  });
+};
+
 export const ChartView: React.FC<ChartViewProps> = ({ interval = '5', range = '1D', symbol }) => {
-  const [isLive, onToggle] = useToggle(true);
+  const [isLive, onToggle] = useToggle(false);
 
   return (
     <div className={chartViewSection}>
       <LiveToggle value={isLive} onChange={onToggle} />
-      <RealTimeChart symbol={symbol?.code || ''} interval={interval} range={range} />
+      {isLive ? (
+        <RealTimeChart symbol={symbol?.code || ''} interval={interval} range={range} />
+      ) : (
+        <FinancialChart data={generateMockData(200)} />
+      )}
     </div>
   );
 };

--- a/web/src/pages/main/components/ChartView/ChartView.tsx
+++ b/web/src/pages/main/components/ChartView/ChartView.tsx
@@ -49,12 +49,21 @@ const generateMockData = (length: number) => {
 export const ChartView: React.FC<ChartViewProps> = ({ interval = '5', range = '1D', symbol }) => {
   const [isLive, onToggle] = useToggle(false);
 
+  const handleSelectRange = (range: {
+    start: string;
+    end: string;
+    startTimestamp: number;
+    endTimestamp: number;
+  }) => {
+    console.log(range);
+  };
+
   return (
     <div className={chartViewSection}>
       <LiveToggle value={isLive} onChange={onToggle} />
       <div style={{ display: isLive ? 'none' : 'block', height: '100%', width: '100%' }}>
         <Suspense>
-          <FinancialChart data={generateMockData(200)} />
+          <FinancialChart data={generateMockData(200)} onSelectRange={handleSelectRange} />
         </Suspense>
       </div>
       <div style={{ display: isLive ? 'block' : 'none', height: '100%', width: '100%' }}>

--- a/web/src/pages/main/components/ChartView/style.css.ts
+++ b/web/src/pages/main/components/ChartView/style.css.ts
@@ -9,4 +9,5 @@ export const chartViewSection = style({
   height: '100%',
   color: '#e0e0e0',
   width: '100%',
+  gap: '16px',
 });

--- a/web/src/pages/main/components/FinancialChart/FinancialChart.tsx
+++ b/web/src/pages/main/components/FinancialChart/FinancialChart.tsx
@@ -1,0 +1,11 @@
+import type { ChartSimilarityBasePriceData } from '@web/shared/api/models/chartSimilarityBasePriceData.ts';
+import CandleStickChart from '../SideChart/CandleStickChart';
+import { financialChartContainer } from './style.css.ts';
+
+export function FinancialChart({ data }: { data: ChartSimilarityBasePriceData }) {
+  return (
+    <div className={financialChartContainer}>
+      <CandleStickChart data={data} />
+    </div>
+  );
+}

--- a/web/src/pages/main/components/FinancialChart/FinancialChart.tsx
+++ b/web/src/pages/main/components/FinancialChart/FinancialChart.tsx
@@ -2,10 +2,20 @@ import type { ChartSimilarityBasePriceData } from '@web/shared/api/models/chartS
 import CandleStickChart from '../SideChart/CandleStickChart';
 import { financialChartContainer } from './style.css.ts';
 
-export function FinancialChart({ data }: { data: ChartSimilarityBasePriceData }) {
+interface FinancialChartProps {
+  data: ChartSimilarityBasePriceData;
+  onSelectRange: (range: {
+    start: string;
+    end: string;
+    startTimestamp: number;
+    endTimestamp: number;
+  }) => void;
+}
+
+export function FinancialChart({ data, onSelectRange }: FinancialChartProps) {
   return (
     <div className={financialChartContainer}>
-      <CandleStickChart data={data} />
+      <CandleStickChart data={data} onSelectRange={onSelectRange} />
     </div>
   );
 }

--- a/web/src/pages/main/components/FinancialChart/index.ts
+++ b/web/src/pages/main/components/FinancialChart/index.ts
@@ -1,0 +1,1 @@
+export { FinancialChart } from './FinancialChart';

--- a/web/src/pages/main/components/FinancialChart/style.css.ts
+++ b/web/src/pages/main/components/FinancialChart/style.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+
+export const financialChartContainer = style({
+  width: '100%',
+  height: 'calc(100% - 32px)',
+});

--- a/web/src/pages/main/components/LiveToggle/LiveToggle.tsx
+++ b/web/src/pages/main/components/LiveToggle/LiveToggle.tsx
@@ -1,0 +1,28 @@
+import { liveDot, toggleButton, toggleButtonActive, toggleContainer } from './style.css';
+
+interface LiveToggleProps {
+  value: boolean;
+  onChange: () => void;
+}
+
+export function LiveToggle({ value, onChange }: LiveToggleProps) {
+  return (
+    <div className={toggleContainer}>
+      <button
+        type="button"
+        className={`${toggleButton} ${value ? toggleButtonActive : ''}`}
+        onClick={() => onChange()}
+        aria-label={`live ${value ? 'on' : 'off'}`}
+      >
+        {value ? (
+          <>
+            <div className={liveDot} />
+            LIVE
+          </>
+        ) : (
+          'DELAYED'
+        )}
+      </button>
+    </div>
+  );
+}

--- a/web/src/pages/main/components/LiveToggle/index.ts
+++ b/web/src/pages/main/components/LiveToggle/index.ts
@@ -1,0 +1,1 @@
+export { LiveToggle } from './LiveToggle';

--- a/web/src/pages/main/components/LiveToggle/style.css.ts
+++ b/web/src/pages/main/components/LiveToggle/style.css.ts
@@ -14,7 +14,7 @@ export const toggleButton = style({
   borderRadius: '16px',
   border: '1px solid rgba(255, 255, 255, 0.2)',
   cursor: 'pointer',
-  transition: 'all 0.3s ease',
+  transition: 'background-color 0.3s ease, border-color 0.3s ease',
   outline: 'none',
   display: 'flex',
   alignItems: 'center',
@@ -50,5 +50,6 @@ export const liveDot = style({
   backgroundColor: '#4ade80',
   borderRadius: '50%',
   marginRight: '4px',
+  willChange: 'background-position',
   animation: `${pulse} 2s infinite`,
 });

--- a/web/src/pages/main/components/LiveToggle/style.css.ts
+++ b/web/src/pages/main/components/LiveToggle/style.css.ts
@@ -1,0 +1,54 @@
+import { keyframes, style } from '@vanilla-extract/css';
+
+export const toggleContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '12px',
+});
+
+export const toggleButton = style({
+  position: 'relative',
+  width: '80px',
+  height: '32px',
+  backgroundColor: 'rgba(255, 255, 255, 0.1)',
+  borderRadius: '16px',
+  border: '1px solid rgba(255, 255, 255, 0.2)',
+  cursor: 'pointer',
+  transition: 'all 0.3s ease',
+  outline: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '12px',
+  fontWeight: '600',
+  color: '#9ca3af',
+
+  ':hover': {
+    backgroundColor: 'rgba(255, 255, 255, 0.15)',
+    borderColor: 'rgba(255, 255, 255, 0.3)',
+  },
+});
+
+export const toggleButtonActive = style({
+  backgroundColor: 'rgba(74, 222, 128, 0.2)',
+  borderColor: '#4ade80',
+  color: '#4ade80',
+
+  ':hover': {
+    backgroundColor: 'rgba(74, 222, 128, 0.3)',
+  },
+});
+
+const pulse = keyframes({
+  '0%': { backgroundPosition: '-1000px 0' },
+  '100%': { backgroundPosition: '1000px 0' },
+});
+
+export const liveDot = style({
+  width: '6px',
+  height: '6px',
+  backgroundColor: '#4ade80',
+  borderRadius: '50%',
+  marginRight: '4px',
+  animation: `${pulse} 2s infinite`,
+});

--- a/web/src/pages/main/components/SideChart/CandleStickChart.tsx
+++ b/web/src/pages/main/components/SideChart/CandleStickChart.tsx
@@ -6,11 +6,20 @@ import ReactApexChart from 'react-apexcharts';
 interface CandleStickChartProps {
   options?: ApexOptions;
   data?: ChartSimilarityBasePriceData;
+  onSelectRange?: (range: {
+    start: string;
+    end: string;
+    startTimestamp: number;
+    endTimestamp: number;
+  }) => void;
 }
 
 const defaultOptions: ApexOptions = {
   chart: {
     type: 'candlestick',
+    selection: {
+      enabled: true,
+    },
   },
   title: {
     text: '',
@@ -51,10 +60,34 @@ const defaultOptions: ApexOptions = {
   },
 };
 
-const CandleStickChart = ({ options, data }: CandleStickChartProps) => {
+const CandleStickChart = ({ options, data, onSelectRange }: CandleStickChartProps) => {
   const chartOptions = useMemo(() => {
-    return { ...defaultOptions, ...options };
-  }, [options]);
+    const baseOptions = {
+      ...defaultOptions,
+      chart: {
+        ...defaultOptions.chart,
+        events: {
+          selection: (_: unknown, { xaxis }: { xaxis: { min: number; max: number } }) => {
+            const startTime = new Date(xaxis.min);
+            const endTime = new Date(xaxis.max);
+
+            const rangeData = {
+              start: startTime.toISOString(),
+              end: endTime.toISOString(),
+              startTimestamp: xaxis.min,
+              endTimestamp: xaxis.max,
+            };
+
+            if (onSelectRange) {
+              onSelectRange(rangeData);
+            }
+          },
+        },
+      },
+    };
+
+    return { ...baseOptions, ...options };
+  }, [options, onSelectRange]);
 
   const chartSeries = useMemo(() => {
     return data?.map(item => {

--- a/web/src/pages/main/components/SideChart/CandleStickChart.tsx
+++ b/web/src/pages/main/components/SideChart/CandleStickChart.tsx
@@ -17,9 +17,6 @@ interface CandleStickChartProps {
 const defaultOptions: ApexOptions = {
   chart: {
     type: 'candlestick',
-    selection: {
-      enabled: true,
-    },
   },
   title: {
     text: '',
@@ -66,6 +63,9 @@ const CandleStickChart = ({ options, data, onSelectRange }: CandleStickChartProp
       ...defaultOptions,
       chart: {
         ...defaultOptions.chart,
+        selection: {
+          enabled: !!onSelectRange,
+        },
         events: {
           selection: (_: unknown, { xaxis }: { xaxis: { min: number; max: number } }) => {
             const startTime = new Date(xaxis.min);

--- a/web/src/shared/components/Helmet/style.css.ts
+++ b/web/src/shared/components/Helmet/style.css.ts
@@ -8,4 +8,5 @@ export const visuallyHidden = style({
   border: 0,
   padding: 0,
   whiteSpace: 'nowrap',
+  overflow: 'hidden',
 });

--- a/web/src/shared/hooks/useToggle.ts
+++ b/web/src/shared/hooks/useToggle.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+type ReturnTypeToggle = [boolean, () => void];
+
+export function useToggle(initialValue = false): ReturnTypeToggle {
+  const [value, setValue] = useState(initialValue);
+
+  const handleToggle = () => {
+    setValue(!value);
+  };
+
+  return [value, handleToggle];
+}

--- a/web/src/shared/hooks/useToggle.ts
+++ b/web/src/shared/hooks/useToggle.ts
@@ -1,13 +1,11 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 type ReturnTypeToggle = [boolean, () => void];
 
 export function useToggle(initialValue = false): ReturnTypeToggle {
   const [value, setValue] = useState(initialValue);
 
-  const handleToggle = () => {
-    setValue(!value);
-  };
+  const handleToggle = useCallback(() => setValue(v => !v), []);
 
   return [value, handleToggle];
 }


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
실시간 차트뿐 아니라 적재된 데이터 기반의 차트를 노출시키고 분석을 위해 Main차트와 Side 차트의 상호작용을 추가하고자 합니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
closes #84 #72 
<!-- close #1 -->

## ✅ 작업 목록
- 자체 데이터 차트/라이브차트 노출
  - 변경은 toggle
- 유사도 검색 시 선택된 range값을 input값으로 전송
- side chart의 선택된 영역으로 main chart가 이동
<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [x] local code lint 검사를 진행하셨나요?
- [x] loca ci test를 진행하셨나요?

## 📚 논의사항
@widse 
- #117 이슈 PR에서 아래 항목 통합 테스트가 필요합니다.
  - 자체 데이터 노출
  - 유사도 검색 시 선택된 range값을 input값으로 전송
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
![ux_chart1](https://github.com/user-attachments/assets/e172e312-07a6-4e54-bf50-4b211db0fdd2)

![ux_chart2](https://github.com/user-attachments/assets/b6753f8e-eb2c-422c-b4a8-2d62d1cae141)

<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 차트 뷰에 실시간(LIVE) 토글 추가 — 실시간/지연 모드 전환 가능.
  * 지연 모드에서 표시되는 금융 캔들스틱 차트 추가.
  * 차트 카드에 빠른 이동용 링크 버튼 추가.
  * 캔들스틱 차트에서 시간 범위 선택 기능 지원.

* **Style**
  * 실시간 토글 스타일 및 펄스 상태 표시기 추가.
  * 차트 레이아웃 간격 및 금융 차트 전용 컨테이너 스타일 개선.

* **Tests**
  * 토글 클릭 시 UI가 “live off”에서 “live on”으로 바뀌는 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->