### PR TITLE
[Feat/#128] chore: 랜딩 주소 변경

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   nginx:
-    container_name: nginx
+    container_name: chart-pattern-nginx
     build:
       context: ./web
       dockerfile: Dockerfile
@@ -14,6 +14,7 @@ services:
       - TZ=Asia/Seoul
 
   db:
+    container_name: chart-pattern-db
     image: mysql:latest
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
@@ -27,6 +28,7 @@ services:
       - ./infra/mysql/data:/var/lib/mysql
 
   api:
+    container_name: chart-pattern-api
     build:
       context: ./api
       dockerfile: Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,24 +6,12 @@ services:
       dockerfile: Dockerfile
     restart: always
     ports:
-      - "80:80" # HTTP
-      - "443:443" # HTTPS
+      - "3001:80" # HTTP
     volumes:
       - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./infra/nginx/letsencrypt:/etc/letsencrypt
-      - ./infra/nginx/www:/var/www/certbot
       - ./infra/nginx/logs:/var/log/nginx
     environment:
       - TZ=Asia/Seoul
-
-  certbot:
-    image: certbot/certbot
-    container_name: certbot
-    volumes:
-      - ./infra/nginx/letsencrypt:/etc/letsencrypt
-      - ./infra/nginx/www:/var/www/certbot
-    depends_on:
-      - nginx
 
   db:
     image: mysql:latest

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -40,15 +40,11 @@ http {
   otel_trace on;
 
   server {
-    listen 443 ssl;
-    server_name frieeren.com;
+    listen 80;
+    server_name _;
     
     limit_req zone=limit burst=20 nodelay;
     limit_req_status 429;
-
-    # https://nginx.org/en/docs/http/configuring_https_servers.html
-    ssl_certificate /etc/letsencrypt/live/frieeren.com-0001/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/frieeren.com-0001/privkey.pem;
     
     location / {
       # otel header 추가
@@ -102,20 +98,6 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       add_header Content-Type application/json;
-    }
-  }
-
-  server {
-    listen 80;
-    server_name frieeren.com;
-
-    location /.well-known/acme-challenge/ {
-      allow all;
-      root /var/www/certbot;
-    }
-
-    location / {
-      return 301 https://$host$request_uri;
     }
   }
 }


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [x] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
기존에는 본 레포에서 인증서 관리를 같이 진행하였는데요. 프로젝트가 추가됨에 따라 신규 진입점(https://github.com/Frieeren/infra/pull/5) 을 추가하여 레포의 기존 서비스를 제거하고자 합니다.
추가적으로 랜딩 주소가 변경됩니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #128 
<!-- close #1 -->

## ✅ 작업 목록
- docker compose certbot 관련 설정값 제거
- nginx.conf ssl 관련 설정 제거
- 랜딩 주소 변경
<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [x] local code lint 검사를 진행하셨나요?
- [x] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Nginx를 HTTP 전용으로 단순화(SSL/HTTPS 및 리다이렉트 제거, ACME 챌린지 블록 제거). 외부 포트가 3001로 변경되어 이제 http://localhost:3001 에서 접속하세요. 도메인 기반 설정 제거. 기존 프록시/캐시 동작은 유지.
- Chores
  - docker-compose 정리: certbot 서비스 삭제, HTTPS 관련 볼륨 제거, 서비스 컨테이너 이름 정규화(nginx/db/api).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->